### PR TITLE
Fix token:multiaddr --api doc in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ or run the explorer in its self-contained-binary form
 (assets are bundled via the `go generate` above.)
 
 ```
-go run ./cmd/stateexplorer explore --bind 0.0.0.0:33333 --api $(cat ~/.lotus/api):$(cat ~/.lotus/token)
+go run ./cmd/stateexplorer explore --bind 0.0.0.0:33333 --api $(cat ~/.lotus/token):$(cat ~/.lotus/api)
 ```
 
 If not explicitly provided as an argument, statediff/stateexplorer will attempt to locate a lotus instance running on the same host by probing your home directory.


### PR DESCRIPTION
I'm not a Go developer, so please double-check, but I'm pretty sure the order was swapped and it should have been `--api token:api` in the README.