### PR TITLE
provide 'sample' and 'time' for use with grafana

### DIFF
--- a/cmd/stateql/lib/lib.go
+++ b/cmd/stateql/lib/lib.go
@@ -183,7 +183,7 @@ func GetGraphQL(c *cli.Context, source sdlib.Datasource) *http.ServeMux {
 						for i := from; to.After(i); i.Add(time.Duration(interval) * time.Second) {
 							ch, err := source.CidAtHeight(p.Context, timeStampToEpoch(i))
 							if err != nil {
-								return nil, fmt.Errorf("Have not indexed a block at height %d", i)
+								return nil, fmt.Errorf("Have not indexed a block at height %d", timeStampToEpoch(i))
 							}
 							if ch == cid.Undef {
 								continue

--- a/cmd/stateql/lib/override.go
+++ b/cmd/stateql/lib/override.go
@@ -417,7 +417,7 @@ func ISO8601(t *time.Time) string {
 	if z, offset := t.Zone(); z == "UTC" {
 		tz = "Z"
 	} else {
-		tz = fmt.Sprintf("%03d00", offset/3600)
+		tz = fmt.Sprintf("%03d:00", offset/3600)
 	}
 	return fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02d%s", t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(),
 		t.Second(), tz)

--- a/cmd/stateql/lib/override.go
+++ b/cmd/stateql/lib/override.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/statediff"
@@ -43,12 +44,13 @@ func AddFields() {
 	})
 
 	LotusBlockHeader__type.AddFieldConfig("Time", &graphql.Field{
-		Name: "Time",
-		Type: graphql.NewNonNull(graphql.Int),
+		Name:        "Time",
+		Description: "ISO8601 timestamp of the time at which this block appears. derived from epoch height.",
+		Type:        graphql.NewNonNull(graphql.String),
 		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 			ts := p.Source.(types.LotusBlockHeader)
 			t := epochToTime(int(ts.Height.Int()))
-			return t.Second, nil
+			return ISO8601(&t), nil
 		},
 	})
 
@@ -408,4 +410,15 @@ func CidString__type__parseLiteral(valueAST ast.Value) interface{} {
 		return nil
 	}
 	return builder.Build()
+}
+
+func ISO8601(t *time.Time) string {
+	var tz string
+	if z, offset := t.Zone(); z == "UTC" {
+		tz = "Z"
+	} else {
+		tz = fmt.Sprintf("%03d00", offset/3600)
+	}
+	return fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02d%s", t.Year, t.Month, t.Day, t.Hour, t.Minute,
+		t.Second, tz)
 }

--- a/cmd/stateql/lib/override.go
+++ b/cmd/stateql/lib/override.go
@@ -419,6 +419,6 @@ func ISO8601(t *time.Time) string {
 	} else {
 		tz = fmt.Sprintf("%03d00", offset/3600)
 	}
-	return fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02d%s", t.Year, t.Month, t.Day, t.Hour, t.Minute,
-		t.Second, tz)
+	return fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02d%s", t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(),
+		t.Second(), tz)
 }

--- a/cmd/stateql/lib/override.go
+++ b/cmd/stateql/lib/override.go
@@ -42,6 +42,16 @@ func AddFields() {
 		},
 	})
 
+	LotusBlockHeader__type.AddFieldConfig("Time", &graphql.Field{
+		Name: "Time",
+		Type: graphql.NewNonNull(graphql.Int),
+		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			ts := p.Source.(types.LotusBlockHeader)
+			t := epochToTime(int(ts.Height.Int()))
+			return t.Second, nil
+		},
+	})
+
 	List__LinkLotusMessage__type.AddFieldConfig("CountOf", &graphql.Field{
 		Name: "CountOf",
 		Args: graphql.FieldConfigArgument{


### PR DESCRIPTION
Add a `sample` top level query that allows range specified off unix time stamp and an 'interval' of granularity.
Add a `time` field to block headers for getting the unix time stamp they are expected to occur at.

fix #94 