### PR TITLE
docs: add multisig example

### DIFF
--- a/cmd/stateql/README.md
+++ b/cmd/stateql/README.md
@@ -149,3 +149,28 @@ query Query {
   }
 }
 ```
+
+Or using `AllOf` to get all multisig signers:
+
+```graphql
+query Query {
+  Height(at: -1) {
+    ParentStateRoot {
+      Actors {
+        AllOf(type: "multisigActor") {
+          Key
+          Value {
+            Head {
+              ...on MultisigV0State {
+                Signers {
+                  All
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
Useful if you have an account address and want to find the address(es) of a multisig actor that your account has access to.