### PR TITLE
Fix-up to store interface

### DIFF
--- a/cmd/stateql/lib/lib.go
+++ b/cmd/stateql/lib/lib.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/statediff"
-	sdlib "github.com/filecoin-project/statediff/lib"
+	iface "github.com/filecoin-project/statediff/lib/interface"
 	"github.com/graphql-go/graphql"
 	"github.com/ipfs/go-cid"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
@@ -37,7 +37,7 @@ type postData struct {
 	Variables map[string]interface{} `json:"variables"`
 }
 
-func GetGraphQL(c *cli.Context, source sdlib.Datasource) *http.ServeMux {
+func GetGraphQL(c *cli.Context, source iface.Datasource) *http.ServeMux {
 	AddFields()
 
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/evanw/esbuild v0.11.5
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-bitfield v0.2.4
-	github.com/filecoin-project/go-bs-postgres-chainnotated v0.0.0-20210406144452-84c363ecaa6f
+	github.com/filecoin-project/go-bs-postgres-chainnotated v0.0.0-20210421230102-321bccf8b648
 	github.com/filecoin-project/go-fil-markets v1.1.9
 	github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0
 	github.com/filecoin-project/go-hamt-ipld/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/filecoin-project/go-bitfield v0.2.0/go.mod h1:CNl9WG8hgR5mttCnUErjcQj
 github.com/filecoin-project/go-bitfield v0.2.3/go.mod h1:CNl9WG8hgR5mttCnUErjcQjGvuiZjRqK9rHVBsQF4oM=
 github.com/filecoin-project/go-bitfield v0.2.4 h1:uZ7MeE+XfM5lqrHJZ93OnhQKc/rveW8p9au0C68JPgk=
 github.com/filecoin-project/go-bitfield v0.2.4/go.mod h1:CNl9WG8hgR5mttCnUErjcQjGvuiZjRqK9rHVBsQF4oM=
-github.com/filecoin-project/go-bs-postgres-chainnotated v0.0.0-20210406144452-84c363ecaa6f h1:gVo0pcCuE8SOVzsn1n+FOXdumY7qARxFo2TZslVBd58=
-github.com/filecoin-project/go-bs-postgres-chainnotated v0.0.0-20210406144452-84c363ecaa6f/go.mod h1:+9NU3Wng6nqpYx61ItNXvsDPEU4JvDckZaIhl0kmcYM=
+github.com/filecoin-project/go-bs-postgres-chainnotated v0.0.0-20210421230102-321bccf8b648 h1:7mZ6riCPYQbt7hRqkgUoqiBlOWdCHcNYbg7ld3mfUxY=
+github.com/filecoin-project/go-bs-postgres-chainnotated v0.0.0-20210421230102-321bccf8b648/go.mod h1:+9NU3Wng6nqpYx61ItNXvsDPEU4JvDckZaIhl0kmcYM=
 github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2 h1:av5fw6wmm58FYMgJeoB/lK9XXrgdugYiTqkdxjTy9k8=
 github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2/go.mod h1:pqTiPHobNkOVM5thSRsHYjyQfq7O5QSCMhvuu9JoDlg=
 github.com/filecoin-project/go-commp-utils v0.0.0-20201119054358-b88f7a96a434 h1:0kHszkYP3hgApcjl5x4rpwONhN9+j7XDobf6at5XfHs=

--- a/lib/interface/datasource.go
+++ b/lib/interface/datasource.go
@@ -1,0 +1,16 @@
+package iface
+
+import (
+	"context"
+
+	"github.com/filecoin-project/lotus/blockstore"
+	"github.com/ipfs/go-cid"
+)
+
+// Datasource is the interface for loading data to share with stateexplorer when needed.
+type Datasource interface {
+	Store() blockstore.Blockstore
+	Head(ctx context.Context) cid.Cid
+	CidAtHeight(ctx context.Context, h int64) (cid.Cid, error)
+	Reload() error
+}

--- a/lib/lazysource.go
+++ b/lib/lazysource.go
@@ -10,19 +10,12 @@ import (
 	"github.com/filecoin-project/lotus/blockstore"
 	abitypes "github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/statediff"
+	iface "github.com/filecoin-project/statediff/lib/interface"
 	"github.com/filecoin-project/statediff/types"
 	"github.com/ipfs/go-cid"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/urfave/cli/v2"
 )
-
-// Datasource is the interface for loading data to share with stateexplorer when needed.
-type Datasource interface {
-	Store() blockstore.Blockstore
-	Head(ctx context.Context) cid.Cid
-	CidAtHeight(ctx context.Context, h int64) (cid.Cid, error)
-	Reload() error
-}
 
 type lazyDs struct {
 	ctx *cli.Context
@@ -150,7 +143,7 @@ func (l *lazyDs) CidAtHeight(ctx context.Context, h int64) (cid.Cid, error) {
 	return cid.Undef, nil
 }
 
-func Lazy(c *cli.Context) (Datasource, error) {
+func Lazy(c *cli.Context) (iface.Datasource, error) {
 	if lazyInst != nil {
 		return lazyInst, nil
 	}
@@ -160,7 +153,7 @@ func Lazy(c *cli.Context) (Datasource, error) {
 		return nil, err
 	}
 
-	if dsc, ok := store.(Datasource); ok {
+	if dsc, ok := store.(iface.Datasource); ok {
 		return dsc, nil
 	}
 

--- a/lib/tstracker/chainbs.go
+++ b/lib/tstracker/chainbs.go
@@ -139,8 +139,12 @@ func (*tcs) DeleteMany([]cid.Cid) error {
 	return errors.New("not supported")
 }
 
-func (*tcs) View(cid.Cid, func([]byte) error) error {
-	return errors.New("not supported")
+func (x *tcs) View(c cid.Cid, f func([]byte) error) error {
+	b, err := x.Get(c)
+	if err != nil {
+		return err
+	}
+	return f(b.RawData())
 }
 
 func (t *tcs) Store() blockstore.Blockstore {

--- a/lib/tstracker/chainbs.go
+++ b/lib/tstracker/chainbs.go
@@ -11,9 +11,10 @@ import (
 
 	pgchainbs "github.com/filecoin-project/go-bs-postgres-chainnotated"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lotus/blockstore"
 	"github.com/filecoin-project/lotus/chain/types"
+	iface "github.com/filecoin-project/statediff/lib/interface"
 	"github.com/ipfs/go-cid"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	logging "github.com/ipfs/go-log/v2"
 )
 
@@ -22,6 +23,7 @@ var log = logging.Logger("tipset-tracker")
 type TrackingChainstore interface {
 	blockstore.Blockstore
 	blockstore.Viewer
+	iface.Datasource
 	io.Closer
 	DeleteMany([]cid.Cid) error
 	View(cid.Cid, func([]byte) error) error

--- a/store.go
+++ b/store.go
@@ -112,6 +112,10 @@ func (*LotusBS) DeleteMany([]cid.Cid) error {
 	return errors.New("not supported")
 }
 
-func (*LotusBS) View(cid.Cid, func([]byte) error) error {
-	return errors.New("not supported")
+func (l *LotusBS) View(c cid.Cid, f func([]byte) error) error {
+	b, err := l.Get(c)
+	if err != nil {
+		return err
+	}
+	return f(b.RawData())
 }

--- a/transform.go
+++ b/transform.go
@@ -584,7 +584,7 @@ func loadV3Map(ctx context.Context, c cid.Cid, store blockstore.Blockstore, as i
 	cborStore := cbor.NewCborStore(store)
 	node, err := hamtv3.LoadNode(ctx, cborStore, c, hamtv3.UseTreeBitWidth(5))
 	if err != nil {
-		return fmt.Errorf("hamt load node errored: %v", err)
+		return fmt.Errorf("hamtV3 load node errored: %v", err)
 	}
 	mapper, err := as.BeginMap(0)
 	if err != nil {


### PR DESCRIPTION
* newer sql store implements datastore interface so a tipset cache isn't put up over it
* the view methods work (although with a copy) so the newer lotus is happy