### PR TITLE
add schema for v5

### DIFF
--- a/messageparams.go
+++ b/messageparams.go
@@ -30,6 +30,17 @@ var marketTable = methodtable{
 	9: methodMeta{"CronTick", types.Type.Any__Repr},
 }
 
+var marketV5Table = methodtable{
+	2: methodMeta{"AddBalance", types.Type.Address__Repr},
+	3: methodMeta{"WithdrawBalance", types.Type.MessageParamsMarketWithdrawBalance__Repr},
+	4: methodMeta{"PublishStorageDeals", types.Type.MessageParamsMarketPublishDeals__Repr},
+	5: methodMeta{"VerifyDealsForActivation", types.Type.MessageParamsMarketVerifyDeals__Repr},
+	6: methodMeta{"ActivateDeals", types.Type.MessageParamsMarketActivateDeals__Repr},
+	7: methodMeta{"OnMinerSectorsTerminate", types.Type.MessageParamsMarketTerminateDeals__Repr},
+	8: methodMeta{"ComputeDataCommitment", types.Type.MessageParamsMarketV5ComputeCommitment__Repr},
+	9: methodMeta{"CronTick", types.Type.Any__Repr},
+}
+
 var minerTable = methodtable{
 	1:  methodMeta{"Constructor", types.Type.MessageParamsMinerConstructor__Repr},
 	2:  methodMeta{"ControlAddresses", types.Type.Any__Repr},
@@ -55,6 +66,8 @@ var minerTable = methodtable{
 	22: methodMeta{"RepayDebt", types.Type.Any__Repr},
 	23: methodMeta{"ChangeOwnerAddress", types.Type.Address__Repr},
 	24: methodMeta{"DisputeWindowedPoSt", types.Type.MessageParamsMinerDisputeWindowedPoSt__Repr},
+	25: methodMeta{"PreCommitSectorBatch", types.Type.MessageParamsMinerPreCommitSectorBatch__Repr},
+	26: methodMeta{"ProveCommitAggregate", types.Type.MessageParamsMinerProveCommitAggregate__Repr},
 }
 
 var multisigTable = methodtable{
@@ -110,10 +123,12 @@ var messageParamTable = map[LotusType]methodtable{
 	MarketActorState:             marketTable,
 	MarketActorV2State:           marketTable,
 	MarketActorV3State:           marketTable,
+	MarketActorV5State:           marketV5Table,
 	StorageMinerActorState:       minerTable,
 	StorageMinerActorV2State:     minerTable,
 	StorageMinerActorV3State:     minerTable,
 	StorageMinerActorV4State:     minerTable,
+	StorageMinerActorV5State:     minerTable,
 	MultisigActorState:           multisigTable,
 	MultisigActorV3State:         multisigTable,
 	PaymentChannelActorState:     paychTable,

--- a/transform.go
+++ b/transform.go
@@ -215,7 +215,7 @@ var LotusActorCodes = map[string]LotusType{
 	cidOf("fil/5/cron"):             CronActorState,
 	cidOf("fil/5/storagepower"):     StoragePowerActorV3State,
 	cidOf("fil/5/storageminer"):     StorageMinerActorV5State,
-	cidOf("fil/5/storagemarket"):    MarketActorV3State,
+	cidOf("fil/5/storagemarket"):    MarketActorV5State,
 	cidOf("fil/5/paymentchannel"):   PaymentChannelActorV3State,
 	cidOf("fil/5/reward"):           RewardActorV2State,
 	cidOf("fil/5/verifiedregistry"): VerifiedRegistryActorV3State,

--- a/transform.go
+++ b/transform.go
@@ -53,6 +53,7 @@ const (
 	MarketActorState                           LotusType = "storageMarketActor"
 	MarketActorV2State                         LotusType = "storageMarketActorV2"
 	MarketActorV3State                         LotusType = "storageMarketActorV3"
+	MarketActorV5State                         LotusType = "storageMarketActorV5"
 	MarketActorProposals                       LotusType = "storageMarketActor.Proposals"
 	MarketActorV2Proposals                     LotusType = "storageMarketActorV2.Proposals"
 	MarketActorV3Proposals                     LotusType = "storageMarketActorV3.Proposals"
@@ -100,6 +101,7 @@ const (
 	StorageMinerActorV3DeadlinePartitionExpiry LotusType = "storageMinerActorV3.Deadlines.Due.Partitions.ExpirationsEpochs"
 	StorageMinerActorV3DeadlinePartitionEarly  LotusType = "storageMinerActorV3.Deadlines.Due.Partitions.EarlyTerminated"
 	StorageMinerActorV4State                   LotusType = "storageMinerActorV4"
+	StorageMinerActorV5State                   LotusType = "storageMinerActorV5"
 	StoragePowerActorState                     LotusType = "storagePowerActor"
 	StoragePowerActorV2State                   LotusType = "storagePowerActorV2"
 	StoragePowerActorV3State                   LotusType = "storagePowerActorV3"
@@ -207,6 +209,18 @@ var LotusActorCodes = map[string]LotusType{
 	cidOf("fil/4/verifiedregistry"): VerifiedRegistryActorV3State,
 	cidOf("fil/4/account"):          AccountActorState,
 	cidOf("fil/4/multisig"):         MultisigActorV3State,
+	// v5
+	cidOf("fil/5/system"):           LotusType("systemActor"),
+	cidOf("fil/5/init"):             InitActorV3State,
+	cidOf("fil/5/cron"):             CronActorState,
+	cidOf("fil/5/storagepower"):     StoragePowerActorV3State,
+	cidOf("fil/5/storageminer"):     StorageMinerActorV5State,
+	cidOf("fil/5/storagemarket"):    MarketActorV3State,
+	cidOf("fil/5/paymentchannel"):   PaymentChannelActorV3State,
+	cidOf("fil/5/reward"):           RewardActorV2State,
+	cidOf("fil/5/verifiedregistry"): VerifiedRegistryActorV3State,
+	cidOf("fil/5/account"):          AccountActorState,
+	cidOf("fil/5/multisig"):         MultisigActorV3State,
 }
 
 var lotusMessageMap = basicnode.Prototype__Map{}
@@ -242,6 +256,7 @@ var LotusPrototypes = map[LotusType]ipld.NodePrototype{
 	StorageMinerActorV3Deadlines:      types.Type.MinerV3Deadlines__Repr,
 	StorageMinerActorV3Deadline:       types.Type.MinerV3Deadline__Repr,
 	StorageMinerActorV4State:          types.Type.MinerV4State__Repr,
+	StorageMinerActorV5State:          types.Type.MinerV5State__Repr,
 	StoragePowerActorState:            types.Type.PowerV0State__Repr,
 	StoragePowerActorV2State:          types.Type.PowerV2State__Repr,
 	StoragePowerActorV3State:          types.Type.PowerV3State__Repr,

--- a/types/gen/lotus.go
+++ b/types/gen/lotus.go
@@ -22,7 +22,7 @@ func accumulateLotus(ts schema.TypeSystem) {
 			schema.SpawnStructField("Timestamp", "Int", false, false),
 			schema.SpawnStructField("BlockSig", "Signature", false, true),
 			schema.SpawnStructField("ForkSignaling", "Int", false, false),
-			schema.SpawnStructField("ParentBaseFee", "BigInt", false, false), //TokenAmount
+			schema.SpawnStructField("ParentBaseFee", "BigInt", false, false), // TokenAmount
 		},
 		schema.StructRepresentation_Tuple{},
 	))
@@ -70,7 +70,7 @@ func accumulateLotus(ts schema.TypeSystem) {
 	ts.Accumulate(schema.SpawnStruct("LotusActors",
 		[]schema.StructField{
 			schema.SpawnStructField("Code", "Link", false, false),
-			schema.SpawnStructField("Head", "Link__LotusActorV4Head", false, false),
+			schema.SpawnStructField("Head", "Link__LotusActorV5Head", false, false),
 			schema.SpawnStructField("Nonce", "Int", false, false),
 			schema.SpawnStructField("Balance", "BigInt", false, false),
 		},
@@ -87,7 +87,7 @@ func accumulateLotus(ts schema.TypeSystem) {
 		},
 		schema.StructRepresentation_Tuple{}))
 	ts.Accumulate(schema.SpawnLinkReference("Link__ListLotusMessage", "List__LinkLotusMessage"))
-	ts.Accumulate(schema.SpawnList("List__LinkLotusMessage", "Link__LotusMessage", false)) //Encoded as AMT
+	ts.Accumulate(schema.SpawnList("List__LinkLotusMessage", "Link__LotusMessage", false)) // Encoded as AMT
 	ts.Accumulate(schema.SpawnLinkReference("Link__LotusMessage", "LotusMessage"))
 	ts.Accumulate(schema.SpawnStruct("LotusMessage",
 		[]schema.StructField{

--- a/types/gen/main.go
+++ b/types/gen/main.go
@@ -9,6 +9,7 @@ import (
 	v2 "github.com/filecoin-project/statediff/types/gen/v2"
 	v3 "github.com/filecoin-project/statediff/types/gen/v3"
 	v4 "github.com/filecoin-project/statediff/types/gen/v4"
+	v5 "github.com/filecoin-project/statediff/types/gen/v5"
 
 	gengraphql "github.com/ipld/go-ipld-graphql/gen"
 	ipld "github.com/ipld/go-ipld-prime"
@@ -80,6 +81,7 @@ func main() {
 	v2.Accumulate(ts)
 	v3.Accumulate(ts)
 	v4.Accumulate(ts)
+	v5.Accumulate(ts)
 	messages.Accumulate(ts)
 
 	if errs := ts.ValidateGraph(); errs != nil {

--- a/types/gen/messages/market.go
+++ b/types/gen/messages/market.go
@@ -49,4 +49,15 @@ func accumulateMarket(ts schema.TypeSystem) {
 			schema.SpawnStructField("SectorType", "RegisteredSealProof", false, false),
 		}, schema.StructRepresentation_Tuple{}))
 
+	ts.Accumulate(schema.SpawnStruct("SectorDataSpec",
+		[]schema.StructField{
+			schema.SpawnStructField("DealIDs", "List__DealID", false, false),
+			schema.SpawnStructField("SectorType", "RegisteredSealProof", false, false),
+		}, schema.StructRepresentation_Tuple{}))
+	ts.Accumulate(schema.SpawnList("List__SectorDataSpec", "SectorDataSpec", false))
+
+	ts.Accumulate(schema.SpawnStruct("MessageParamsMarketV5ComputeCommitment",
+		[]schema.StructField{
+			schema.SpawnStructField("Inputs", "List__SectorDataSpec", false, false),
+		}, schema.StructRepresentation_Tuple{}))
 }

--- a/types/gen/messages/miner.go
+++ b/types/gen/messages/miner.go
@@ -137,4 +137,17 @@ func accumulateMiner(ts schema.TypeSystem) {
 			schema.SpawnStructField("Deadline", "Int", false, false),
 			schema.SpawnStructField("PoStIndex", "Int", false, false),
 		}, schema.StructRepresentation_Tuple{}))
+
+	ts.Accumulate(schema.SpawnList("List__MinerV0SectorPreCommitInfo", "MinerV0SectorPreCommitInfo", false))
+
+	ts.Accumulate(schema.SpawnStruct("MessageParamsMinerPreCommitSectorBatch",
+		[]schema.StructField{
+			schema.SpawnStructField("Sectors", "List__MinerV0SectorPreCommitInfo", false, false),
+		}, schema.StructRepresentation_Tuple{}))
+
+	ts.Accumulate(schema.SpawnStruct("MessageParamsMinerProveCommitAggregate",
+		[]schema.StructField{
+			schema.SpawnStructField("SectorNumbers", "BitField", false, false),
+			schema.SpawnStructField("AggregateProof", "Bytes", false, false),
+		}, schema.StructRepresentation_Tuple{}))
 }

--- a/types/gen/v5/main.go
+++ b/types/gen/v5/main.go
@@ -1,0 +1,42 @@
+package v5
+
+import (
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+// Accumulate defines schema for the filecoin v5 state types.
+func Accumulate(ts schema.TypeSystem) {
+	accumulateMiner(ts)
+	accumulateMarket(ts)
+
+	ts.Accumulate(schema.SpawnUnion("LotusActorV5Head", []schema.TypeName{
+		"MinerV5State",
+		"MarketV5State",
+
+		"MinerV4State",
+
+		"MarketV3State",
+		"MinerV3State",
+		"PowerV3State",
+		"InitV3State",
+		"VerifregV3State",
+		"PaychV3State",
+		"MultisigV3State",
+
+		"MarketV2State",
+		"MinerV2State",
+		"PowerV2State",
+		"RewardV2State",
+		"AccountV0State",
+		"CronV0State",
+		"InitV0State",
+		"MarketV0State",
+		"MinerV0State",
+		"MultisigV0State",
+		"PaychV0State",
+		"PowerV0State",
+		"RewardV0State",
+		"VerifregV0State",
+	}, schema.UnionRepresentation_Kinded{}))
+	ts.Accumulate(schema.SpawnLinkReference("Link__LotusActorV5Head", "LotusActorV5Head"))
+}

--- a/types/gen/v5/market.go
+++ b/types/gen/v5/market.go
@@ -1,0 +1,26 @@
+package v5
+
+import (
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+func accumulateMarket(ts schema.TypeSystem) {
+	// Note: state is identical to v3 but method signature of ComputeDataCommitment has changed
+	ts.Accumulate(schema.SpawnStruct("MarketV5State",
+		[]schema.StructField{
+			schema.SpawnStructField("Proposals", "Link__MarketV3RawDealProposal", false, false),     // AMTv3[DealID]DealProposal
+			schema.SpawnStructField("States", "Link__MarketV3DealState", false, false),              // AMTv3[DealID]DealState
+			schema.SpawnStructField("PendingProposals", "Link__MarketV3DealProposal", false, false), // HAMTv3[DealCid]DealProposal
+			schema.SpawnStructField("EscrowTable", "Link__V3BalanceTable", false, false),            // BalanceTable
+			schema.SpawnStructField("LockedTable", "Link__V3BalanceTable", false, false),            // BalanceTable
+			schema.SpawnStructField("NextID", "DealID", false, false),
+			schema.SpawnStructField("DealOpsByEpoch", "Link__MarketV3MultimapDealID", false, false), // SetMultimap, HAMTv3[epoch]Set
+			schema.SpawnStructField("LastCron", "ChainEpoch", false, false),
+			schema.SpawnStructField("TotalClientLockedCollateral", "BigInt", false, false),   // TokenAmount
+			schema.SpawnStructField("TotalProviderLockedCollateral", "BigInt", false, false), // TokenAmount
+			schema.SpawnStructField("TotalClientStorageFee", "BigInt", false, false),         // TokenAmount
+		},
+		schema.StructRepresentation_Tuple{},
+	))
+	ts.Accumulate(schema.SpawnLinkReference("Link__MarketV5State", "MarketV5State"))
+}

--- a/types/gen/v5/miner.go
+++ b/types/gen/v5/miner.go
@@ -1,0 +1,29 @@
+package v5
+
+import (
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+func accumulateMiner(ts schema.TypeSystem) {
+	ts.Accumulate(schema.SpawnStruct("MinerV5State",
+		[]schema.StructField{
+			schema.SpawnStructField("Info", "Link__MinerV2Info", false, false),
+			schema.SpawnStructField("PreCommitDeposits", "BigInt", false, false), // TokenAmount
+			schema.SpawnStructField("LockedFunds", "BigInt", false, false),       // TokenAmount
+			schema.SpawnStructField("VestingFunds", "Link__MinerV0VestingFunds", false, false),
+			schema.SpawnStructField("FeeDebt", "BigInt", false, false),                                    // TokenAmount
+			schema.SpawnStructField("InitialPledge", "BigInt", false, false),                              // TokenAmount
+			schema.SpawnStructField("PreCommittedSectors", "Link__MinerV3SectorPreCommits", false, false), // Map, HAMT[SectorNumber]SectorPreCommitOnChainInfo
+			schema.SpawnStructField("PreCommittedSectorsCleanUp", "Link", false, false),                   // BitFieldQueue (AMT[Epoch]*BitField) (was PreCommittedSectorsExpiry)
+			schema.SpawnStructField("AllocatedSectors", "Link__BitField", false, false),
+			schema.SpawnStructField("Sectors", "Link__MinerV3SectorInfo", false, false), // Array, AMT[SectorNumber]SectorOnChainInfo (sparse)
+			schema.SpawnStructField("ProvingPeriodStart", "ChainEpoch", false, false),
+			schema.SpawnStructField("CurrentDeadline", "Int", false, false),
+			schema.SpawnStructField("Deadlines", "Link__MinerV3Deadlines", false, false),
+			schema.SpawnStructField("EarlyTerminations", "BitField", false, false),
+			schema.SpawnStructField("DeadlineCronActive", "Bool", false, false),
+		},
+		schema.StructRepresentation_Tuple{},
+	))
+	ts.Accumulate(schema.SpawnLinkReference("Link__MinerV5State", "MinerV5State"))
+}

--- a/types/ipldsch_types.go
+++ b/types/ipldsch_types.go
@@ -79,6 +79,8 @@ type typeSlab struct {
 	Link__LotusActorV3Head__Repr _Link__LotusActorV3Head__ReprPrototype
 	Link__LotusActorV4Head       _Link__LotusActorV4Head__Prototype
 	Link__LotusActorV4Head__Repr _Link__LotusActorV4Head__ReprPrototype
+	Link__LotusActorV5Head       _Link__LotusActorV5Head__Prototype
+	Link__LotusActorV5Head__Repr _Link__LotusActorV5Head__ReprPrototype
 	Link__LotusActors       _Link__LotusActors__Prototype
 	Link__LotusActors__Repr _Link__LotusActors__ReprPrototype
 	Link__LotusMessage       _Link__LotusMessage__Prototype
@@ -159,6 +161,8 @@ type typeSlab struct {
 	Link__MinerV3State__Repr _Link__MinerV3State__ReprPrototype
 	Link__MinerV4State       _Link__MinerV4State__Prototype
 	Link__MinerV4State__Repr _Link__MinerV4State__ReprPrototype
+	Link__MinerV5State       _Link__MinerV5State__Prototype
+	Link__MinerV5State__Repr _Link__MinerV5State__ReprPrototype
 	Link__MultimapDealID       _Link__MultimapDealID__Prototype
 	Link__MultimapDealID__Repr _Link__MultimapDealID__ReprPrototype
 	Link__MultisigV0State       _Link__MultisigV0State__Prototype
@@ -235,6 +239,8 @@ type typeSlab struct {
 	List__MinerTerminationDecl__Repr _List__MinerTerminationDecl__ReprPrototype
 	List__MinerV0DeadlineLink       _List__MinerV0DeadlineLink__Prototype
 	List__MinerV0DeadlineLink__Repr _List__MinerV0DeadlineLink__ReprPrototype
+	List__MinerV0SectorPreCommitInfo       _List__MinerV0SectorPreCommitInfo__Prototype
+	List__MinerV0SectorPreCommitInfo__Repr _List__MinerV0SectorPreCommitInfo__ReprPrototype
 	List__MinerV0VestingFund       _List__MinerV0VestingFund__Prototype
 	List__MinerV0VestingFund__Repr _List__MinerV0VestingFund__ReprPrototype
 	List__MinerV2DeadlineLink       _List__MinerV2DeadlineLink__Prototype
@@ -245,6 +251,8 @@ type typeSlab struct {
 	List__Multiaddrs__Repr _List__Multiaddrs__ReprPrototype
 	List__PoStProof       _List__PoStProof__Prototype
 	List__PoStProof__Repr _List__PoStProof__ReprPrototype
+	List__SectorDataSpec       _List__SectorDataSpec__Prototype
+	List__SectorDataSpec__Repr _List__SectorDataSpec__ReprPrototype
 	List__SectorNumber       _List__SectorNumber__Prototype
 	List__SectorNumber__Repr _List__SectorNumber__ReprPrototype
 	LotusActorV2Head       _LotusActorV2Head__Prototype
@@ -253,6 +261,8 @@ type typeSlab struct {
 	LotusActorV3Head__Repr _LotusActorV3Head__ReprPrototype
 	LotusActorV4Head       _LotusActorV4Head__Prototype
 	LotusActorV4Head__Repr _LotusActorV4Head__ReprPrototype
+	LotusActorV5Head       _LotusActorV5Head__Prototype
+	LotusActorV5Head__Repr _LotusActorV5Head__ReprPrototype
 	LotusActors       _LotusActors__Prototype
 	LotusActors__Repr _LotusActors__ReprPrototype
 	LotusBeaconEntry       _LotusBeaconEntry__Prototype
@@ -367,6 +377,8 @@ type typeSlab struct {
 	MarketV2State__Repr _MarketV2State__ReprPrototype
 	MarketV3State       _MarketV3State__Prototype
 	MarketV3State__Repr _MarketV3State__ReprPrototype
+	MarketV5State       _MarketV5State__Prototype
+	MarketV5State__Repr _MarketV5State__ReprPrototype
 	Merge       _Merge__Prototype
 	Merge__Repr _Merge__ReprPrototype
 	MessageParamsInitExecParams       _MessageParamsInitExecParams__Prototype
@@ -379,6 +391,8 @@ type typeSlab struct {
 	MessageParamsMarketPublishDeals__Repr _MessageParamsMarketPublishDeals__ReprPrototype
 	MessageParamsMarketTerminateDeals       _MessageParamsMarketTerminateDeals__Prototype
 	MessageParamsMarketTerminateDeals__Repr _MessageParamsMarketTerminateDeals__ReprPrototype
+	MessageParamsMarketV5ComputeCommitment       _MessageParamsMarketV5ComputeCommitment__Prototype
+	MessageParamsMarketV5ComputeCommitment__Repr _MessageParamsMarketV5ComputeCommitment__ReprPrototype
 	MessageParamsMarketVerifyDeals       _MessageParamsMarketVerifyDeals__Prototype
 	MessageParamsMarketVerifyDeals__Repr _MessageParamsMarketVerifyDeals__ReprPrototype
 	MessageParamsMarketWithdrawBalance       _MessageParamsMarketWithdrawBalance__Prototype
@@ -409,6 +423,10 @@ type typeSlab struct {
 	MessageParamsMinerDisputeWindowedPoSt__Repr _MessageParamsMinerDisputeWindowedPoSt__ReprPrototype
 	MessageParamsMinerExtendSectorExpiration       _MessageParamsMinerExtendSectorExpiration__Prototype
 	MessageParamsMinerExtendSectorExpiration__Repr _MessageParamsMinerExtendSectorExpiration__ReprPrototype
+	MessageParamsMinerPreCommitSectorBatch       _MessageParamsMinerPreCommitSectorBatch__Prototype
+	MessageParamsMinerPreCommitSectorBatch__Repr _MessageParamsMinerPreCommitSectorBatch__ReprPrototype
+	MessageParamsMinerProveCommitAggregate       _MessageParamsMinerProveCommitAggregate__Prototype
+	MessageParamsMinerProveCommitAggregate__Repr _MessageParamsMinerProveCommitAggregate__ReprPrototype
 	MessageParamsMinerProveCommitSector       _MessageParamsMinerProveCommitSector__Prototype
 	MessageParamsMinerProveCommitSector__Repr _MessageParamsMinerProveCommitSector__ReprPrototype
 	MessageParamsMinerReportFault       _MessageParamsMinerReportFault__Prototype
@@ -511,6 +529,8 @@ type typeSlab struct {
 	MinerV3State__Repr _MinerV3State__ReprPrototype
 	MinerV4State       _MinerV4State__Prototype
 	MinerV4State__Repr _MinerV4State__ReprPrototype
+	MinerV5State       _MinerV5State__Prototype
+	MinerV5State__Repr _MinerV5State__ReprPrototype
 	ModVerifyParams       _ModVerifyParams__Prototype
 	ModVerifyParams__Repr _ModVerifyParams__ReprPrototype
 	Multiaddr       _Multiaddr__Prototype
@@ -559,6 +579,8 @@ type typeSlab struct {
 	RewardV2State__Repr _RewardV2State__ReprPrototype
 	SealVerifyInfo       _SealVerifyInfo__Prototype
 	SealVerifyInfo__Repr _SealVerifyInfo__ReprPrototype
+	SectorDataSpec       _SectorDataSpec__Prototype
+	SectorDataSpec__Repr _SectorDataSpec__ReprPrototype
 	SectorNumber       _SectorNumber__Prototype
 	SectorNumber__Repr _SectorNumber__ReprPrototype
 	SectorSize       _SectorSize__Prototype
@@ -732,6 +754,10 @@ type _Link__LotusActorV3Head struct{ x ipld.Link }
 type Link__LotusActorV4Head = *_Link__LotusActorV4Head
 type _Link__LotusActorV4Head struct{ x ipld.Link }
 
+// Link__LotusActorV5Head matches the IPLD Schema type "Link__LotusActorV5Head".  It has link kind.
+type Link__LotusActorV5Head = *_Link__LotusActorV5Head
+type _Link__LotusActorV5Head struct{ x ipld.Link }
+
 // Link__LotusActors matches the IPLD Schema type "Link__LotusActors".  It has link kind.
 type Link__LotusActors = *_Link__LotusActors
 type _Link__LotusActors struct{ x ipld.Link }
@@ -891,6 +917,10 @@ type _Link__MinerV3State struct{ x ipld.Link }
 // Link__MinerV4State matches the IPLD Schema type "Link__MinerV4State".  It has link kind.
 type Link__MinerV4State = *_Link__MinerV4State
 type _Link__MinerV4State struct{ x ipld.Link }
+
+// Link__MinerV5State matches the IPLD Schema type "Link__MinerV5State".  It has link kind.
+type Link__MinerV5State = *_Link__MinerV5State
+type _Link__MinerV5State struct{ x ipld.Link }
 
 // Link__MultimapDealID matches the IPLD Schema type "Link__MultimapDealID".  It has link kind.
 type Link__MultimapDealID = *_Link__MultimapDealID
@@ -1072,6 +1102,12 @@ type _List__MinerV0DeadlineLink struct {
 	x []_Link__MinerV0Deadline__Maybe
 }
 
+// List__MinerV0SectorPreCommitInfo matches the IPLD Schema type "List__MinerV0SectorPreCommitInfo".  It has list kind.
+type List__MinerV0SectorPreCommitInfo = *_List__MinerV0SectorPreCommitInfo
+type _List__MinerV0SectorPreCommitInfo struct {
+	x []_MinerV0SectorPreCommitInfo
+}
+
 // List__MinerV0VestingFund matches the IPLD Schema type "List__MinerV0VestingFund".  It has list kind.
 type List__MinerV0VestingFund = *_List__MinerV0VestingFund
 type _List__MinerV0VestingFund struct {
@@ -1100,6 +1136,12 @@ type _List__Multiaddrs struct {
 type List__PoStProof = *_List__PoStProof
 type _List__PoStProof struct {
 	x []_PoStProof
+}
+
+// List__SectorDataSpec matches the IPLD Schema type "List__SectorDataSpec".  It has list kind.
+type List__SectorDataSpec = *_List__SectorDataSpec
+type _List__SectorDataSpec struct {
+	x []_SectorDataSpec
 }
 
 // List__SectorNumber matches the IPLD Schema type "List__SectorNumber".  It has list kind.
@@ -1249,11 +1291,68 @@ func (_PowerV0State) _LotusActorV4Head__member() {}
 func (_RewardV0State) _LotusActorV4Head__member() {}
 func (_VerifregV0State) _LotusActorV4Head__member() {}
 
+// LotusActorV5Head matches the IPLD Schema type "LotusActorV5Head".  It has Union type-kind, and may be interrogated like map kind.
+type LotusActorV5Head = *_LotusActorV5Head
+type _LotusActorV5Head struct {
+	tag uint
+	x1 _MinerV5State
+	x2 _MarketV5State
+	x3 _MinerV4State
+	x4 _MarketV3State
+	x5 _MinerV3State
+	x6 _PowerV3State
+	x7 _InitV3State
+	x8 _VerifregV3State
+	x9 _PaychV3State
+	x10 _MultisigV3State
+	x11 _MarketV2State
+	x12 _MinerV2State
+	x13 _PowerV2State
+	x14 _RewardV2State
+	x15 _AccountV0State
+	x16 _CronV0State
+	x17 _InitV0State
+	x18 _MarketV0State
+	x19 _MinerV0State
+	x20 _MultisigV0State
+	x21 _PaychV0State
+	x22 _PowerV0State
+	x23 _RewardV0State
+	x24 _VerifregV0State
+}
+type _LotusActorV5Head__iface interface {
+	_LotusActorV5Head__member()
+}
+func (_MinerV5State) _LotusActorV5Head__member() {}
+func (_MarketV5State) _LotusActorV5Head__member() {}
+func (_MinerV4State) _LotusActorV5Head__member() {}
+func (_MarketV3State) _LotusActorV5Head__member() {}
+func (_MinerV3State) _LotusActorV5Head__member() {}
+func (_PowerV3State) _LotusActorV5Head__member() {}
+func (_InitV3State) _LotusActorV5Head__member() {}
+func (_VerifregV3State) _LotusActorV5Head__member() {}
+func (_PaychV3State) _LotusActorV5Head__member() {}
+func (_MultisigV3State) _LotusActorV5Head__member() {}
+func (_MarketV2State) _LotusActorV5Head__member() {}
+func (_MinerV2State) _LotusActorV5Head__member() {}
+func (_PowerV2State) _LotusActorV5Head__member() {}
+func (_RewardV2State) _LotusActorV5Head__member() {}
+func (_AccountV0State) _LotusActorV5Head__member() {}
+func (_CronV0State) _LotusActorV5Head__member() {}
+func (_InitV0State) _LotusActorV5Head__member() {}
+func (_MarketV0State) _LotusActorV5Head__member() {}
+func (_MinerV0State) _LotusActorV5Head__member() {}
+func (_MultisigV0State) _LotusActorV5Head__member() {}
+func (_PaychV0State) _LotusActorV5Head__member() {}
+func (_PowerV0State) _LotusActorV5Head__member() {}
+func (_RewardV0State) _LotusActorV5Head__member() {}
+func (_VerifregV0State) _LotusActorV5Head__member() {}
+
 // LotusActors matches the IPLD Schema type "LotusActors".  It has Struct type-kind, and may be interrogated like map kind.
 type LotusActors = *_LotusActors
 type _LotusActors struct {
 	Code _Link
-	Head _Link__LotusActorV4Head
+	Head _Link__LotusActorV5Head
 	Nonce _Int
 	Balance _BigInt
 }
@@ -1955,6 +2054,22 @@ type _MarketV3State struct {
 	TotalClientStorageFee _BigInt
 }
 
+// MarketV5State matches the IPLD Schema type "MarketV5State".  It has Struct type-kind, and may be interrogated like map kind.
+type MarketV5State = *_MarketV5State
+type _MarketV5State struct {
+	Proposals _Link__MarketV3RawDealProposal
+	States _Link__MarketV3DealState
+	PendingProposals _Link__MarketV3DealProposal
+	EscrowTable _Link__V3BalanceTable
+	LockedTable _Link__V3BalanceTable
+	NextID _DealID
+	DealOpsByEpoch _Link__MarketV3MultimapDealID
+	LastCron _ChainEpoch
+	TotalClientLockedCollateral _BigInt
+	TotalProviderLockedCollateral _BigInt
+	TotalClientStorageFee _BigInt
+}
+
 // Merge matches the IPLD Schema type "Merge".  It has Struct type-kind, and may be interrogated like map kind.
 type Merge = *_Merge
 type _Merge struct {
@@ -1994,6 +2109,12 @@ type MessageParamsMarketTerminateDeals = *_MessageParamsMarketTerminateDeals
 type _MessageParamsMarketTerminateDeals struct {
 	Epoch _ChainEpoch
 	DealIDs _List__DealID
+}
+
+// MessageParamsMarketV5ComputeCommitment matches the IPLD Schema type "MessageParamsMarketV5ComputeCommitment".  It has Struct type-kind, and may be interrogated like map kind.
+type MessageParamsMarketV5ComputeCommitment = *_MessageParamsMarketV5ComputeCommitment
+type _MessageParamsMarketV5ComputeCommitment struct {
+	Inputs _List__SectorDataSpec
 }
 
 // MessageParamsMarketVerifyDeals matches the IPLD Schema type "MessageParamsMarketVerifyDeals".  It has Struct type-kind, and may be interrogated like map kind.
@@ -2089,6 +2210,19 @@ type _MessageParamsMinerDisputeWindowedPoSt struct {
 type MessageParamsMinerExtendSectorExpiration = *_MessageParamsMinerExtendSectorExpiration
 type _MessageParamsMinerExtendSectorExpiration struct {
 	Extension _List__MinerExpirationExtend
+}
+
+// MessageParamsMinerPreCommitSectorBatch matches the IPLD Schema type "MessageParamsMinerPreCommitSectorBatch".  It has Struct type-kind, and may be interrogated like map kind.
+type MessageParamsMinerPreCommitSectorBatch = *_MessageParamsMinerPreCommitSectorBatch
+type _MessageParamsMinerPreCommitSectorBatch struct {
+	Sectors _List__MinerV0SectorPreCommitInfo
+}
+
+// MessageParamsMinerProveCommitAggregate matches the IPLD Schema type "MessageParamsMinerProveCommitAggregate".  It has Struct type-kind, and may be interrogated like map kind.
+type MessageParamsMinerProveCommitAggregate = *_MessageParamsMinerProveCommitAggregate
+type _MessageParamsMinerProveCommitAggregate struct {
+	SectorNumbers _BitField
+	AggregateProof _Bytes
 }
 
 // MessageParamsMinerProveCommitSector matches the IPLD Schema type "MessageParamsMinerProveCommitSector".  It has Struct type-kind, and may be interrogated like map kind.
@@ -2595,6 +2729,26 @@ type _MinerV4State struct {
 	DeadlineCronActive _Bool
 }
 
+// MinerV5State matches the IPLD Schema type "MinerV5State".  It has Struct type-kind, and may be interrogated like map kind.
+type MinerV5State = *_MinerV5State
+type _MinerV5State struct {
+	Info _Link__MinerV2Info
+	PreCommitDeposits _BigInt
+	LockedFunds _BigInt
+	VestingFunds _Link__MinerV0VestingFunds
+	FeeDebt _BigInt
+	InitialPledge _BigInt
+	PreCommittedSectors _Link__MinerV3SectorPreCommits
+	PreCommittedSectorsCleanUp _Link
+	AllocatedSectors _Link__BitField
+	Sectors _Link__MinerV3SectorInfo
+	ProvingPeriodStart _ChainEpoch
+	CurrentDeadline _Int
+	Deadlines _Link__MinerV3Deadlines
+	EarlyTerminations _BitField
+	DeadlineCronActive _Bool
+}
+
 // ModVerifyParams matches the IPLD Schema type "ModVerifyParams".  It has Struct type-kind, and may be interrogated like map kind.
 type ModVerifyParams = *_ModVerifyParams
 type _ModVerifyParams struct {
@@ -2838,6 +2992,13 @@ type _SealVerifyInfo struct {
 	Proof _Bytes
 	SealedCID _Link
 	UnsealedCID _Link
+}
+
+// SectorDataSpec matches the IPLD Schema type "SectorDataSpec".  It has Struct type-kind, and may be interrogated like map kind.
+type SectorDataSpec = *_SectorDataSpec
+type _SectorDataSpec struct {
+	DealIDs _List__DealID
+	SectorType _RegisteredSealProof
 }
 
 // SectorNumber matches the IPLD Schema type "SectorNumber".  It has int kind.

--- a/types/ipldsch_types.go
+++ b/types/ipldsch_types.go
@@ -115,6 +115,8 @@ type typeSlab struct {
 	Link__MarketV3RawDealProposal__Repr _Link__MarketV3RawDealProposal__ReprPrototype
 	Link__MarketV3State       _Link__MarketV3State__Prototype
 	Link__MarketV3State__Repr _Link__MarketV3State__ReprPrototype
+	Link__MarketV5State       _Link__MarketV5State__Prototype
+	Link__MarketV5State__Repr _Link__MarketV5State__ReprPrototype
 	Link__MinerV0Deadline       _Link__MinerV0Deadline__Prototype
 	Link__MinerV0Deadline__Repr _Link__MinerV0Deadline__ReprPrototype
 	Link__MinerV0Deadlines       _Link__MinerV0Deadlines__Prototype
@@ -825,6 +827,10 @@ type _Link__MarketV3RawDealProposal struct{ x ipld.Link }
 // Link__MarketV3State matches the IPLD Schema type "Link__MarketV3State".  It has link kind.
 type Link__MarketV3State = *_Link__MarketV3State
 type _Link__MarketV3State struct{ x ipld.Link }
+
+// Link__MarketV5State matches the IPLD Schema type "Link__MarketV5State".  It has link kind.
+type Link__MarketV5State = *_Link__MarketV5State
+type _Link__MarketV5State struct{ x ipld.Link }
 
 // Link__MinerV0Deadline matches the IPLD Schema type "Link__MinerV0Deadline".  It has link kind.
 type Link__MinerV0Deadline = *_Link__MinerV0Deadline


### PR DESCRIPTION
Miner actor gains two additional methods:
 - PreCommitSectorBatch
 - ProveCommitAggregate

Miner actor state has one field renamed:
 - PreCommittedSectorsExpiry -> PreCommittedSectorsCleanUp 

Market actor changes the signature of one method:
 - ComputeDataCommitment (now takes a list of inputs)
